### PR TITLE
Footer: replace status widget with link to status page

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -13,19 +13,16 @@
           <a href="/sector/advocacy/">Sectors</a><br />
         </p>
       </div>
-      <div class="col-md-6 col-lg-3">
+      <div class="col-md-6 col-lg-3 mb-2 mb-md-0">
         <p>
           <a href="/about-us">About Us</a><br />
           <a href="/blog">Blog</a><br />
           <a href="https://support.controlshiftlabs.com/">Support</a><br />
-          <a href="https://developers.controlshiftlabs.com/">Developers</a>
+          <a href="https://developers.controlshiftlabs.com/">Developers</a><br />
+          <a href="https://status.controlshiftlabs.com">Platform Status</a>
         </p>
       </div>
-      <div class="col-md-6 col-lg-3 ">
-        <div class="status">
-          <span class="status-indicator"><i class="indicator none icon-circle"></i></span>
-          <span class="status-description"></span>
-        </div>
+      <div class="col-md-6 col-lg-3">
         <p class="d-block d-sm-none d-lg-block">
           PO Box 1194<br />
           Hudson, NY 12534<br />

--- a/_src/index.js
+++ b/_src/index.js
@@ -14,13 +14,6 @@ import netlifyIdentity from 'netlify-identity-widget'
 import { setupValidation } from './validation'
 import { setupHamburger } from './hamburger'
 
-jQuery.getJSON('https://cfyy3d57ng36.statuspage.io/api/v2/status.json', (data) => {
-  jQuery(() => {
-    jQuery('.status-description').text(data.status.description)
-    jQuery('.status-indicator span').replaceWith(jQuery(`<i class="indicator ${data.status.indicator} fa fa-circle"></i>`))
-  })
-})
-
 jQuery(() => {
   setupHamburger()
   setupValidation()


### PR DESCRIPTION
This updates the footer, removing the embedded status indicator and adding a normal link to the status page.

![image](https://user-images.githubusercontent.com/1977279/206567710-72c20e1a-f225-42cf-b95a-1a0ca4997545.png)
