### PR TITLE
Embed platform status badge

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -31,8 +31,8 @@
         </p>
       </div>
       <div class="col-md-6 col-lg-3">
-        <p>Other products</p>
-        <p><a href="https://www.visitthem.org"><img src="/assets/images/logos/logo-visit-them.svg" alt="Visit Them" /></a></p>
+        <p>Platform status</p>
+        <iframe src="https://status.controlshiftlabs.com/badge?theme=dark" width="250" height="30" frameborder="0" scrolling="no"></iframe>
       </div>
     </div>
     <hr class="m-0" />


### PR DESCRIPTION
The embedded status badge replaces the link to VisitThem.

[Better Stack's docs](https://betterstack.com/docs/uptime/working-with-status-pages/embeddable-status-badge/) mention that the badge style can be customized with CSS but doesn't explain how. I didn't spend any time trying to accomplish this, but can give it a try if others think it's worth updating.

![image](https://github.com/controlshift/website-v2/assets/134911/1852d05a-1c9e-40f3-aa2e-e0b1bf7dc496)
