### PR TITLE
Add Sign In link to navigation

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -16,6 +16,7 @@
       <li class="nav-item"><a class="nav-link" href="/sector/advocacy">Sectors</a></li>
       <li class="nav-item"><a class="nav-link" href="/case-studies/">Case Studies</a></li>
       <li class="nav-item"><a class="nav-link" href="/how-it-works/">Why Distributed</a></li>
+      <li class="nav-item"><a class="nav-link" href="https://go.controlshift.app/signups/sending_login_instructions">Sign In</a></li>
       <li class="nav-item"><a role="button" class="nav-link btn btn-outline-primary lets-talk white" href="https://go.controlshift.app/signups/new_for_location">Sign Up</a></li>
     </ul>
   </div>
@@ -69,6 +70,9 @@
             </a>
           </div>
         </div>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link no-padding" href="https://go.controlshift.app/signups/sending_login_instructions">Sign In</a>
       </li>
       <li class="nav-item">
         <a role="button" class="nav-link btn btn-outline-primary lets-talk white" href="https://go.controlshift.app/signups/new_for_location">Sign Up</a>


### PR DESCRIPTION
This adds a "Sign In" link to the header navigation.
![image](https://github.com/user-attachments/assets/be917ee1-2eea-49e4-88b3-6698e583526f)

On mobile it looks like this:
![image](https://github.com/user-attachments/assets/db622e63-2b1f-4194-8e5d-51b486b66ee5)

The link goes to [the new form](https://go.controlshift.app/signups/sending_login_instructions) where a confused person can enter their email address to get an email with a link to sign in to their ControlShift instance.

Q: What about EU customers?
A: We've decided that it's okay for now that this only works as intended for customers hosted in the US datacenter, given the extremely low usage of the EU datacenter.