### PR TITLE
Set up a CSS file for styling the Help Center

### DIFF
--- a/_src/helpcenter.scss
+++ b/_src/helpcenter.scss
@@ -1,0 +1,9 @@
+/* This file is used to style the Help Center. It's hosted on the marketing site domain for ease of maintenance. */
+
+$csl-blue: #1091c2;
+
+#searchBar {
+  button {
+    background-color: $csl-blue;
+  }
+}

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -11,7 +11,8 @@ export default {
 
   entry: {
     app: './_src/index.js',
-    admin: './_src/admin.js'
+    admin: './_src/admin.js',
+    helpcenter: './_src/helpcenter.scss'
   },
   plugins: [
     new FaviconsWebpackPlugin({


### PR DESCRIPTION
As part of our transition from ZenDesk to HelpScout, we want to apply some custom styles to our new [help center pages](https://controlshift-labs.helpscoutdocs.com/). HelpScout allows us to supply a URL to a stylesheet that will then be applied on those pages.

This PR creates a stylesheet we can serve from `https://www.controlshiftlabs.com/assets/helpcenter.css`. For now, this stylesheet only has one simple rule in it, but once it exists, we can iterate on it.