### PR TITLE
Help center CSS: Space category cards 4 across

### DIFF
--- a/_src/css/helpcenter/_categories.scss
+++ b/_src/css/helpcenter/_categories.scss
@@ -1,14 +1,16 @@
 // Display icons for each category
 
 .category-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1.5em 0.75em;
-  justify-content: space-evenly;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  grid-gap: 10px;
   align-items: stretch;
 
   .category {
-    width: 220px;
+    // The built-in styles have widths like "29%", which we do not want as part of our grid layout.
+    // We need to use !important to ensure we also override the mobile-specific percentage width.
+    width: auto !important;
+
     margin: 0;
 
     &:before {

--- a/_src/css/helpcenter/_categories.scss
+++ b/_src/css/helpcenter/_categories.scss
@@ -3,19 +3,26 @@
 .category-list {
   display: flex;
   flex-wrap: wrap;
+  gap: 1.5em 0.75em;
+  justify-content: space-evenly;
   align-items: stretch;
-}
 
-.category-list .category::before {
-  content: "";
-  display: block;
-  text-align: center;
-  font-family: "Material Symbols Outlined";
-  font-weight: normal;
-  font-style: normal;
-  font-size: 2em;
-  margin-bottom: 10px;
-  color: #333;
+  .category {
+    width: 220px;
+    margin: 0;
+
+    &:before {
+      content: "";
+      display: block;
+      text-align: center;
+      font-family: "Material Symbols Outlined";
+      font-weight: normal;
+      font-style: normal;
+      font-size: 2em;
+      margin-bottom: 10px;
+      color: #333;
+    }
+  }
 }
 
 // Announcements


### PR DESCRIPTION
This updates the layout of the help center homepage so that on desktop-size screens, the cards are in a grid with 4 cards across.
![image](https://github.com/user-attachments/assets/b7454f3f-96ee-4a47-94d8-5ece957e42a5)
![image](https://github.com/user-attachments/assets/1707971e-fb6e-4ba6-8053-2ba80dc1f8d8)

The grid gracefully collapses to 3, 2, or 1 card across on smaller screens.
![image](https://github.com/user-attachments/assets/135cdbff-cfae-4747-a7ea-06ed88091abc)
![image](https://github.com/user-attachments/assets/7b561034-a8ec-4363-a9fd-9a699eeec6a3)
![image](https://github.com/user-attachments/assets/224888b7-816c-42ff-b465-059ad05cbdf4)