### PR TITLE
Help Center CSS: Use Graphik font

### DIFF
--- a/_src/css/helpcenter/_fonts.scss
+++ b/_src/css/helpcenter/_fonts.scss
@@ -17,9 +17,9 @@
 }
 
 body {
-  font-family: Graphik-Medium, sans-serif;
+  font-family: Graphik-Regular, sans-serif;
 }
 
-p, ul {
-  font-family: Graphik-Regular, sans-serif;
+h1, h2, h3, h4, h5, h6, button {
+  font-family: Graphik-Medium, sans-serif;
 }

--- a/_src/css/helpcenter/_fonts.scss
+++ b/_src/css/helpcenter/_fonts.scss
@@ -1,0 +1,25 @@
+@font-face {
+  font-family: Graphik-Medium;
+  src: url('fonts/Graphik-Medium-Web.eot');
+  src: url('fonts/Graphik-Medium-Web.eot?#iefix') format('embedded-opentype'),
+  url('fonts/Graphik-Medium-Web.woff2') format('woff2'),
+  url('fonts/Graphik-Medium-Web.woff') format('woff');
+  font-display: swap;
+}
+
+@font-face {
+  font-family: Graphik-Regular;
+  src: url('fonts/Graphik-Regular-Web.eot');
+  src: url('fonts/Graphik-Regular-Web.eot?#iefix') format('embedded-opentype'),
+  url('fonts/Graphik-Regular-Web.woff2') format('woff2'),
+  url('fonts/Graphik-Regular-Web.woff') format('woff');
+  font-display: swap;
+}
+
+body {
+  font-family: Graphik-Medium, sans-serif;
+}
+
+p, ul {
+  font-family: Graphik-Regular, sans-serif;
+}

--- a/_src/helpcenter.scss
+++ b/_src/helpcenter.scss
@@ -4,6 +4,7 @@ $csl-blue: #1091c2;
 $yellow: #fdd455;
 $black: #333;
 
+@import "css/helpcenter/_fonts";
 @import "css/helpcenter/_header";
 @import "css/helpcenter/_search-bar";
 @import "css/helpcenter/_categories";


### PR DESCRIPTION
This updates the help center CSS to specify that we should use the Graphik font, the same way we do on the marketing site.

We include the `@font-face` so that the CSS knows what "Graphik-Medium" and "Graphik-Regular" are. The font face declaration is copied from the one in `css/_typography.scss`, except that we're not renaming it to "Grafik".

I've tested this (by pulling up the help center in my browser and replacing the stylesheet link with the one from the netlify preview) and it seems to work!