### PR TITLE
Update _fonts.scss

### DIFF
--- a/_src/css/helpcenter/_fonts.scss
+++ b/_src/css/helpcenter/_fonts.scss
@@ -21,7 +21,7 @@ body {
 }
 
 // bold text doesnt stand out in graphik regular
-strong {
+strong, b {
   font-family: Graphik-Medium, sans-serif;
   color: #000;
 }


### PR DESCRIPTION
apparently in helpscout half  of the bold texts are `strong` and half are `b`... I assumed they'd all be the same.