### PR TITLE
Fix distorted graphics on Feature pages

### DIFF
--- a/_layouts/feature.html
+++ b/_layouts/feature.html
@@ -7,7 +7,7 @@ layout: default
     <div class="col-md-6 feature-title">
       <h1>{{page.title}}</h1>
     </div>
-    <div class="col-md-6">
+    <div class="col-md-6 position-relative">
       {% if page.image_class %}
         <img src="/assets/images/features/hero/{{page.image_slug}}.svg" class="img-fluid feature-image {{page.image_class}}" alt="" />
       {% else %}

--- a/_layouts/tabbed-feature.html
+++ b/_layouts/tabbed-feature.html
@@ -4,7 +4,7 @@ layout: default
 
 <div class="container pt-2">
   <div class="row mt-3">
-    <div class="col-md-12 feature-header feature-tab-header">
+    <div class="col-md-12 feature-header feature-tab-header position-relative">
       <h1>{{page.title}}</h1>
 
       <div class="feature-tabs">


### PR DESCRIPTION
Fixes CON-995

The Feature pages (events, groups, campaigns/efforts) are supposed to have a cute little graphic in the header. We recently noticed that the graphic was weirdly stretched out and sitting down at the bottom of the page instead. This PR fixes it.

I suspect this might have broken during the Bootstrap upgrade a while back -- I vaguely remember something about a change involving `position: relative` and the grid layout.